### PR TITLE
add IF NOT EXISTS to postgis extension creation

### DIFF
--- a/migrations/0003_weather.sql
+++ b/migrations/0003_weather.sql
@@ -1,4 +1,4 @@
-CREATE EXTENSION postgis;
+CREATE EXTENSION IF NOT EXISTS postgis;
 
 CREATE TYPE observation_type AS ENUM ('historical', 'recent', 'current', 'forecast');
 


### PR DESCRIPTION
When applying migrations on database with postgis already enabled, the migration fails.