### PR TITLE
Fix operationId of /current_weather in api spec

### DIFF
--- a/docs/brightsky.yml
+++ b/docs/brightsky.yml
@@ -144,7 +144,7 @@ paths:
         This endpoint is different from the other weather endpoints in that it does not directly correspond to any of the data available from the DWD Open Data server. Instead, it is a best-effort solution to reflect current weather conditions by compiling SYNOP observations from the past one and a half hours.
 
         To set the location for which to retrieve weather, you must supply both `lat` and `lon` _or_ one of `dwd_station_id`, `wmo_station_id`, or `source_id`.
-      operationId: getWeather
+      operationId: getCurrentWeather
       parameters:
         - $ref: '#/components/parameters/lat'
         - $ref: '#/components/parameters/lon'


### PR DESCRIPTION
I was seeing 
```
Exception in thread "main" org.openapitools.codegen.SpecValidationException: There were issues with the specification. The option can be disabled via validateSpec (Maven/Gradle) or --skip-validate-spec (CLI).
 | Error count: 1, Warning count: 0
Errors: 
	-attribute paths.'/current_weather'(get).operationId is repeated

	at org.openapitools.codegen.config.CodegenConfigurator.toContext(CodegenConfigurator.java:480)
	at org.openapitools.codegen.config.CodegenConfigurator.toClientOptInput(CodegenConfigurator.java:507)
	at org.openapitools.codegen.cmd.Generate.execute(Generate.java:423)
	at org.openapitools.codegen.cmd.OpenApiGeneratorCommand.run(OpenApiGeneratorCommand.java:32)
	at org.openapitools.codegen.OpenAPIGenerator.main(OpenAPIGenerator.java:61)

```